### PR TITLE
chore: rename crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "spray"
+name = "spragga"
 version = "1.0.0"
 dependencies = [
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ description = "A scalable concurrent priority queue with relaxed ordering semant
 edition     = "2021"
 keywords    = ["priority-queue", "concurrent", "lock-free", "data-structures", "skip-list"]
 license     = "MIT"
-name        = "spray"
-repository  = "https://github.com/maschad/spray"
+name        = "spragga"
+repository  = "https://github.com/maschad/spragga"
 version     = "1.0.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spray
+# Spragga
 
 A Rust implementation of the SprayList data structure - a scalable concurrent priority queue with relaxed ordering semantics.
 
@@ -54,13 +54,13 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spray = "1.0.0"
+spragga = "1.0.0"
 ```
 
 ### Basic Example
 
 ```rust
-use spray::SprayList;
+use spragga::SprayList;
 
 fn main() {
     // Create a new SprayList
@@ -82,7 +82,7 @@ fn main() {
 ### Concurrent Example
 
 ```rust
-use spray::SprayList;
+use spragga::SprayList;
 use std::sync::Arc;
 use std::thread;
 

--- a/benches/spraylist_bench.rs
+++ b/benches/spraylist_bench.rs
@@ -8,7 +8,7 @@
 #![allow(clippy::semicolon_if_nothing_returned)]
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use spray::{SprayList, SprayParams};
+use spragga::{SprayList, SprayParams};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -119,7 +119,7 @@ fn run_throughput_benchmark(config: BenchConfig) -> PerfMetrics {
         let handle = thread::spawn(move || {
             barrier_clone.wait(); // Synchronize start
 
-            let mut rng = spray::rng::MarsagliaXOR::new((thread_id as u32).wrapping_mul(31) + 1);
+            let mut rng = spragga::rng::MarsagliaXOR::new((thread_id as u32).wrapping_mul(31) + 1);
             let thread_start = Instant::now();
             let ops_per_thread = thread_config.total_ops / thread_config.num_threads;
             let mut local_ops = 0;

--- a/examples/relaxed_ordering.rs
+++ b/examples/relaxed_ordering.rs
@@ -1,4 +1,4 @@
-use spray::SprayList;
+use spragga::SprayList;
 use std::collections::HashMap;
 #[allow(clippy::cast_precision_loss)]
 fn main() {

--- a/src/bin/throughput_test.rs
+++ b/src/bin/throughput_test.rs
@@ -1,4 +1,4 @@
-use spray::SprayList;
+use spragga::SprayList;
 use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier};
@@ -57,7 +57,7 @@ fn run_throughput_test(config: TestConfig) -> f64 {
         let handle = thread::spawn(move || {
             barrier_clone.wait(); // Synchronize start
 
-            let mut rng = spray::rng::MarsagliaXOR::new(
+            let mut rng = spragga::rng::MarsagliaXOR::new(
                 u32::try_from(thread_id).unwrap().wrapping_mul(31) + 1,
             );
             let thread_start = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use spray::SprayList;
+use spragga::SprayList;
 use std::sync::Arc;
 use std::thread;
 use std::time::Instant;

--- a/src/spraylist.rs
+++ b/src/spraylist.rs
@@ -51,7 +51,7 @@
 //! ## Basic Example
 //!
 //! ```
-//! use spray::SprayList;
+//! use spragga::SprayList;
 //!
 //! let spray = SprayList::new();
 //!
@@ -70,7 +70,7 @@
 //! ## Concurrent Example
 //!
 //! ```
-//! use spray::SprayList;
+//! use spragga::SprayList;
 //! use std::sync::Arc;
 //! use std::thread;
 //!
@@ -122,7 +122,7 @@
 //! ## Custom Parameters
 //!
 //! ```
-//! use spray::{SprayList, SprayParams};
+//! use spragga::{SprayList, SprayParams};
 //!
 //! // Create custom parameters for smaller lists
 //! let params = SprayParams {
@@ -163,7 +163,7 @@ use std::sync::Arc;
 /// # Examples
 ///
 /// ```
-/// use spray::SprayParams;
+/// use spragga::SprayParams;
 ///
 /// // Create default parameters
 /// let params = SprayParams::default();
@@ -300,7 +300,7 @@ const fn floor_log_2(n: usize) -> usize {
 /// # Examples
 ///
 /// ```
-/// use spray::SprayList;
+/// use spragga::SprayList;
 /// use std::sync::Arc;
 /// use std::thread;
 ///
@@ -351,7 +351,7 @@ impl<
     /// # Examples
     ///
     /// ```
-    /// use spray::SprayList;
+    /// use spragga::SprayList;
     ///
     /// let spray: SprayList<i32, String> = SprayList::new();
     /// assert!(spray.is_empty());
@@ -376,7 +376,7 @@ impl<
     /// # Examples
     ///
     /// ```
-    /// use spray::{SprayList, SprayParams};
+    /// use spragga::{SprayList, SprayParams};
     ///
     /// // Create parameters optimized for small lists
     /// let params = SprayParams {
@@ -411,7 +411,7 @@ impl<
     /// # Examples
     ///
     /// ```
-    /// use spray::SprayList;
+    /// use spragga::SprayList;
     /// use std::sync::Arc;
     /// use std::thread;
     ///
@@ -443,7 +443,7 @@ impl<
     /// # Examples
     ///
     /// ```
-    /// use spray::SprayList;
+    /// use spragga::SprayList;
     ///
     /// let spray = SprayList::new();
     ///
@@ -485,7 +485,7 @@ impl<
     /// # Examples
     ///
     /// ```
-    /// use spray::SprayList;
+    /// use spragga::SprayList;
     ///
     /// let spray = SprayList::new();
     /// spray.insert(&5, &"five");
@@ -502,7 +502,7 @@ impl<
     /// # Concurrent Example
     ///
     /// ```
-    /// use spray::SprayList;
+    /// use spragga::SprayList;
     /// use std::sync::Arc;
     /// use std::thread;
     ///
@@ -792,7 +792,7 @@ impl<
     /// # Examples
     ///
     /// ```
-    /// use spray::SprayList;
+    /// use spragga::SprayList;
     ///
     /// let spray = SprayList::new();
     /// assert_eq!(spray.len(), 0);
@@ -816,7 +816,7 @@ impl<
     /// # Examples
     ///
     /// ```
-    /// use spray::SprayList;
+    /// use spragga::SprayList;
     ///
     /// let spray = SprayList::new();
     /// assert!(spray.is_empty());
@@ -849,7 +849,7 @@ impl<
     /// # Examples
     ///
     /// ```
-    /// use spray::SprayList;
+    /// use spragga::SprayList;
     ///
     /// let spray = SprayList::new();
     /// assert_eq!(spray.peek_min(), None);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all references in documentation and examples to use the new project name "Spragga" instead of "Spray".
  - Revised README and in-code documentation to reflect the new crate name and repository URL.

- **Chores**
  - Renamed the package in configuration files and updated repository links to match the new project name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->